### PR TITLE
add powerCaps.AoAc for S0 (low power idle mode)

### DIFF
--- a/ClassicShellSrc/ClassicStartMenu/ClassicStartMenuDLL/MenuContainer.cpp
+++ b/ClassicShellSrc/ClassicStartMenu/ClassicStartMenuDLL/MenuContainer.cpp
@@ -7905,7 +7905,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 				}
 				break;
 			case MENU_SLEEP:
-				g_StdOptions[i].options=(!s_bNoClose && (powerCaps.SystemS1 || powerCaps.SystemS2 || powerCaps.SystemS3))?MENU_ENABLED|MENU_EXPANDED:0;
+				g_StdOptions[i].options=(!s_bNoClose && (powerCaps.SystemS1 || powerCaps.SystemS2 || powerCaps.SystemS3 || powerCaps.AoAc))?MENU_ENABLED|MENU_EXPANDED:0;
 				break;
 			case MENU_HIBERNATE:
 				g_StdOptions[i].options=(!s_bNoClose && bHibernate)?MENU_ENABLED|MENU_EXPANDED:0;


### PR DESCRIPTION
newer devices (as ThinkPad X1C6) support _lower power idle mode_ - a deeper sleep that does not report as `S1`, `S2` or `S3`, but as `S0` flag - available in `powerCaps.AcA0`

https://msdn.microsoft.com/en-us/library/windows/desktop/aa373215(v=vs.85).aspx