### PR TITLE
Fix for recent Windows Insider builds (#11)

### DIFF
--- a/ClassicStartSrc/ClassicStartMenu/ClassicStartMenuDLL/MenuContainer.cpp
+++ b/ClassicStartSrc/ClassicStartMenu/ClassicStartMenuDLL/MenuContainer.cpp
@@ -770,9 +770,6 @@ CMenuContainer::~CMenuContainer( void )
 	if (m_SearchIcons)
 		DeleteObject(m_SearchIcons);
 	if (m_pProgramsTree) m_pProgramsTree->Release();
-
-	if (s_pFrameworkInputPane && m_InputCookie)
-		s_pFrameworkInputPane->Unadvise(m_InputCookie);
 }
 
 void CMenuContainer::AddFirstFolder( IShellItem *pFolder, std::vector<MenuItem> &items, int options )
@@ -6215,6 +6212,10 @@ LRESULT CMenuContainer::OnDestroy( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 		CloseThemeData(m_ScrollTheme);
 		m_ScrollTheme=NULL;
 	}
+
+    if (s_pFrameworkInputPane && m_InputCookie)
+        s_pFrameworkInputPane->Unadvise(m_InputCookie);
+
 	return 0;
 }
 


### PR DESCRIPTION
CMenuContainer object was not destroyed when Start Menu window was closed.

It was referenced by IFrameworkInputPane::AdviseWithHWND call (to be able
to receive input pane notifications). The problem was that dereferencing
(IFrameworkInputPane::Unadvise) was called from CMenuContainer destructor
that is called only when object's refcount goes to zero.

In previous Windows versions it somehow worked, because for some reason
CMenuContainer object was no longer referenced when its window was
destroyed.

Apparently there was some change in IFrameworkInputPane handling in recent
Windows builds (starting with 17692).

To fix the issue we have to call IFrameworkInputPane::Unadvise() when
CMenuContainer's window is about to be destroyed.