### PR TITLE
Build improvements

### DIFF
--- a/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
@@ -1,12 +1,14 @@
 REM ***** Collect PDBs
 
-del Final\ClassicStartPDB_%CS_VERSION_STR%.zip
+set CS_SYMBOLS_NAME=ClassicStartPDB_%CS_VERSION_STR%.7z
+
+if exist Final\%CS_SYMBOLS_NAME% del Final\%CS_SYMBOLS_NAME%
 cd Output
-7z a ..\Final\ClassicStartPDB_%CS_VERSION_STR%.zip PDB32 PDB64
+7z a -mx9 ..\Final\%CS_SYMBOLS_NAME% PDB32 PDB64
 cd ..
 
 if defined APPVEYOR (
-	appveyor PushArtifact Final\ClassicStartPDB_%CS_VERSION_STR%.zip
+	appveyor PushArtifact Final\%CS_SYMBOLS_NAME%
 )
 
 cd ..

--- a/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
@@ -13,11 +13,6 @@ if defined APPVEYOR (
 
 cd ..
 
-REM ***** Collect Sources
-
-del ClassicStartSetup\Final\ClassicStartSrc_%CS_VERSION_STR%.zip
-7z a -r -x!*.intermediate.manifest -x!*.embed.manifest -x!*_i.h -x!Website\ ClassicStartSetup\Final\ClassicStartSrc_%CS_VERSION_STR%.zip *.h *.cpp *.rc *.vcproj *.ini *.def *.ico *.idl *.rgs *.jpg *.manifest *.wxl *.wxs *.sln *.bat *.bmp *.txt *.html *.rtf *.gif *.png *.hhp *.hhc ??-??.dll
-
 REM ***** Collect Localization files
 
 del ClassicStartSetup\Final\ClassicStartLoc.zip

--- a/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildArchives.bat
@@ -1,10 +1,10 @@
 REM ***** Collect PDBs
 
+echo -- Creating symbols package
 set CS_SYMBOLS_NAME=ClassicStartPDB_%CS_VERSION_STR%.7z
 
-if exist Final\%CS_SYMBOLS_NAME% del Final\%CS_SYMBOLS_NAME%
 cd Output
-7z a -mx9 ..\Final\%CS_SYMBOLS_NAME% PDB32 PDB64
+7z a -mx9 ..\Final\%CS_SYMBOLS_NAME% PDB32 PDB64 > nul
 cd ..
 
 if defined APPVEYOR (
@@ -15,9 +15,11 @@ cd ..
 
 REM ***** Collect Localization files
 
-del ClassicStartSetup\Final\ClassicStartLoc.zip
+echo -- Creating localization package
 cd Localization
-7z a -r -x!en-US -x!*WixUI_en-us.wxl -x!*.adml -x!*.admx -x!*LocComments.txt ..\ClassicStartSetup\Final\ClassicStartLoc.zip English ..\ClassicExplorer\ExplorerL10N.ini ..\ClassicStartMenu\StartMenuL10N.ini ..\ClassicStartMenu\StartMenuHelper\StartMenuHelperL10N.ini English\ClassicStartText-en-US.wxl English\ClassicStartEULA.rtf
+7z a -r -x!en-US -x!*WixUI_en-us.wxl -x!*.adml -x!*.admx -x!*LocComments.txt ..\ClassicStartSetup\Final\ClassicStartLoc.zip English ..\ClassicExplorer\ExplorerL10N.ini ..\ClassicStartMenu\StartMenuL10N.ini ..\ClassicStartMenu\StartMenuHelper\StartMenuHelperL10N.ini English\ClassicStartText-en-US.wxl English\ClassicStartEULA.rtf > nul
 cd ..
 
 cd ClassicStartSetup
+
+exit /b 0

--- a/ClassicStartSrc/ClassicStartSetup/BuildBinaries.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildBinaries.bat
@@ -109,6 +109,23 @@ copy /B ..\ClassicStartMenu\StartMenuHelper\Setup64\StartMenuHelper64.pdb Output
 copy /B Output\x64\StartMenuHelper64.dll Output\PDB64 > nul
 
 
+REM ********* Source Index PDBs
+
+set PDBSTR_PATH="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\srcsrv\pdbstr.exe"
+
+if exist %PDBSTR_PATH% (
+	echo --- Adding source index to PDBs
+	call CreateSourceIndex.bat ..\.. > Output\pdbstr.txt
+
+	for %%f in (Output\PDB32\*.pdb) do (
+		%PDBSTR_PATH% -w -p:%%f -s:srcsrv -i:Output\pdbstr.txt
+	)
+
+	for %%f in (Output\PDB64\*.pdb) do (
+		%PDBSTR_PATH% -w -p:%%f -s:srcsrv -i:Output\pdbstr.txt
+	)
+)
+
 REM ********* Build ADMX
 echo --- ADMX
 if exist Output\PolicyDefinitions.zip (

--- a/ClassicStartSrc/ClassicStartSetup/BuildBinaries.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildBinaries.bat
@@ -1,111 +1,116 @@
+if exist Output rd /Q /S Output
 md Output
-del /Q /S Output\*.*
 md Output\x64
 md Output\PDB32
 md Output\PDB64
 
+echo -- Compiling
+
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
 REM ********* Build 64-bit solution
-"%MSBuildDir%MSBuild.exe" ..\ClassicStart.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="x64" /verbosity:minimal
+echo --- 64bit
+"%MSBuildDir%MSBuild.exe" ..\ClassicStart.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="x64" /verbosity:quiet /nologo
 @if ERRORLEVEL 1 exit /b 1
 
 REM ********* Build 32-bit solution (must be after 64-bit)
-"%MSBuildDir%MSBuild.exe" ..\ClassicStart.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32" /verbosity:minimal
+echo --- 32bit
+"%MSBuildDir%MSBuild.exe" ..\ClassicStart.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32" /verbosity:quiet /nologo
 @if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Make en-US.dll
 cd ..
-start /wait ClassicStartSetup\ClassicStartUtility\Release\ClassicStartUtility.exe makeEN ClassicExplorer\Setup\ClassicExplorer32.dll ClassicStartMenu\Setup\ClassicStartMenuDLL.dll ClassicIE\Setup\ClassicIEDLL_32.dll ClassicStartUpdate\Release\ClassicStartUpdate.exe
+ClassicStartSetup\ClassicStartUtility\Release\ClassicStartUtility.exe makeEN ClassicExplorer\Setup\ClassicExplorer32.dll ClassicStartMenu\Setup\ClassicStartMenuDLL.dll ClassicIE\Setup\ClassicIEDLL_32.dll ClassicStartUpdate\Release\ClassicStartUpdate.exe
 @if ERRORLEVEL 1 exit /b 1
 
-start /wait ClassicStartSetup\ClassicStartUtility\Release\ClassicStartUtility.exe extract en-US.dll en-US.csv
-copy en-US.dll Localization\English
-move en-US.csv Localization\English
+ClassicStartSetup\ClassicStartUtility\Release\ClassicStartUtility.exe extract en-US.dll en-US.csv
+copy /B en-US.dll Localization\English > nul
+move en-US.csv Localization\English > nul
 
 cd ClassicStartSetup
 
 
 REM ********* Copy binaries
 
-copy /B ..\ClassicExplorer\Setup\ClassicExplorer32.dll Output
-copy /B ..\ClassicExplorer\Setup\ClassicExplorerSettings.exe Output
-copy /B ..\ClassicIE\Setup\ClassicIEDLL_32.dll Output
-copy /B ..\ClassicIE\Setup\ClassicIE_32.exe Output
-copy /B ..\ClassicStartMenu\Setup\ClassicStartMenu.exe Output
-copy /B ..\ClassicStartMenu\Setup\ClassicStartMenuDLL.dll Output
-copy /B ..\ClassicStartUpdate\Release\ClassicStartUpdate.exe Output
-copy /B ..\ClassicStartMenu\StartMenuHelper\Setup\StartMenuHelper32.dll Output
-copy /B ..\ClassicStartSetup\SetupHelper\Release\SetupHelper.exe Output
+copy /B ..\ClassicExplorer\Setup\ClassicExplorer32.dll Output > nul
+copy /B ..\ClassicExplorer\Setup\ClassicExplorerSettings.exe Output > nul
+copy /B ..\ClassicIE\Setup\ClassicIEDLL_32.dll Output > nul
+copy /B ..\ClassicIE\Setup\ClassicIE_32.exe Output > nul
+copy /B ..\ClassicStartMenu\Setup\ClassicStartMenu.exe Output > nul
+copy /B ..\ClassicStartMenu\Setup\ClassicStartMenuDLL.dll Output > nul
+copy /B ..\ClassicStartUpdate\Release\ClassicStartUpdate.exe Output > nul
+copy /B ..\ClassicStartMenu\StartMenuHelper\Setup\StartMenuHelper32.dll Output > nul
+copy /B ..\ClassicStartSetup\SetupHelper\Release\SetupHelper.exe Output > nul
 
-copy /B ..\ClassicExplorer\Setup64\ClassicExplorer64.dll Output\x64
-copy /B ..\ClassicIE\Setup64\ClassicIEDLL_64.dll Output\x64
-copy /B ..\ClassicIE\Setup64\ClassicIE_64.exe Output\x64
-copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenu.exe Output\x64
-copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenuDLL.dll Output\x64
-copy /B ..\ClassicStartMenu\StartMenuHelper\Setup64\StartMenuHelper64.dll Output\x64
+copy /B ..\ClassicExplorer\Setup64\ClassicExplorer64.dll Output\x64 > nul
+copy /B ..\ClassicIE\Setup64\ClassicIEDLL_64.dll Output\x64 > nul
+copy /B ..\ClassicIE\Setup64\ClassicIE_64.exe Output\x64 > nul
+copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenu.exe Output\x64 > nul
+copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenuDLL.dll Output\x64 > nul
+copy /B ..\ClassicStartMenu\StartMenuHelper\Setup64\StartMenuHelper64.dll Output\x64 > nul
 
-copy /B "..\ClassicStartMenu\Skins\Classic Skin.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Full Glass.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Smoked Glass.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Windows Aero.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Windows Basic.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Windows XP Luna.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Windows 8.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Metro.skin" Output
-copy /B "..\ClassicStartMenu\Skins\Classic Skin.skin7" Output
-copy /B "..\ClassicStartMenu\Skins\Windows Aero.skin7" Output
-copy /B "..\ClassicStartMenu\Skins\Windows 8.skin7" Output
-copy /B "..\ClassicStartMenu\Skins\Midnight.skin7" Output
-copy /B "..\ClassicStartMenu\Skins\Metro.skin7" Output
-copy /B "..\ClassicStartMenu\Skins\Metallic.skin7" Output
+copy /B "..\ClassicStartMenu\Skins\Classic Skin.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Full Glass.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Smoked Glass.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows Aero.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows Basic.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows XP Luna.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows 8.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Metro.skin" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Classic Skin.skin7" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows Aero.skin7" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Windows 8.skin7" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Midnight.skin7" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Metro.skin7" Output > nul
+copy /B "..\ClassicStartMenu\Skins\Metallic.skin7" Output > nul
 
 
 REM ********* Collect debug info
 
 REM Explorer 32
-copy /B ..\ClassicExplorer\Setup\ClassicExplorer32.pdb Output\PDB32
-copy /B Output\ClassicExplorer32.dll Output\PDB32
-copy /B ..\ClassicExplorer\Setup\ClassicExplorerSettings.pdb Output\PDB32
-copy /B Output\ClassicExplorerSettings.exe Output\PDB32
+copy /B ..\ClassicExplorer\Setup\ClassicExplorer32.pdb Output\PDB32 > nul
+copy /B Output\ClassicExplorer32.dll Output\PDB32 > nul
+copy /B ..\ClassicExplorer\Setup\ClassicExplorerSettings.pdb Output\PDB32 > nul
+copy /B Output\ClassicExplorerSettings.exe Output\PDB32 > nul
 
 REM Explorer 64
-copy /B ..\ClassicExplorer\Setup64\ClassicExplorer64.pdb Output\PDB64
-copy /B Output\x64\ClassicExplorer64.dll Output\PDB64
+copy /B ..\ClassicExplorer\Setup64\ClassicExplorer64.pdb Output\PDB64 > nul
+copy /B Output\x64\ClassicExplorer64.dll Output\PDB64 > nul
 
 REM IE 32
-copy /B ..\ClassicIE\Setup\ClassicIEDLL_32.pdb Output\PDB32
-copy /B Output\ClassicIEDLL_32.dll Output\PDB32
-copy /B ..\ClassicIE\Setup\ClassicIE_32.exe Output\PDB32
-copy /B Output\ClassicIE_32.exe Output\PDB32
+copy /B ..\ClassicIE\Setup\ClassicIEDLL_32.pdb Output\PDB32 > nul
+copy /B Output\ClassicIEDLL_32.dll Output\PDB32 > nul
+copy /B ..\ClassicIE\Setup\ClassicIE_32.exe Output\PDB32 > nul
+copy /B Output\ClassicIE_32.exe Output\PDB32 > nul
 
 REM IE 64
-copy /B ..\ClassicIE\Setup64\ClassicIEDLL_64.pdb Output\PDB64
-copy /B Output\x64\ClassicIEDLL_64.dll Output\PDB64
-copy /B ..\ClassicIE\Setup64\ClassicIE_64.exe Output\PDB64
-copy /B Output\x64\ClassicIE_64.exe Output\PDB64
+copy /B ..\ClassicIE\Setup64\ClassicIEDLL_64.pdb Output\PDB64 > nul
+copy /B Output\x64\ClassicIEDLL_64.dll Output\PDB64 > nul
+copy /B ..\ClassicIE\Setup64\ClassicIE_64.exe Output\PDB64 > nul
+copy /B Output\x64\ClassicIE_64.exe Output\PDB64 > nul
 
 REM Menu 32
-copy /B ..\ClassicStartMenu\Setup\ClassicStartMenu.pdb Output\PDB32
-copy /B Output\ClassicStartMenu.exe Output\PDB32
-copy /B ..\ClassicStartMenu\Setup\ClassicStartMenuDLL.pdb Output\PDB32
-copy /B Output\ClassicStartMenuDLL.dll Output\PDB32
-copy /B ..\ClassicStartMenu\StartMenuHelper\Setup\StartMenuHelper32.pdb Output\PDB32
-copy /B Output\StartMenuHelper32.dll Output\PDB32
-copy /B ..\ClassicStartUpdate\Release\ClassicStartUpdate.pdb Output\PDB32
-copy /B Output\ClassicStartUpdate.exe Output\PDB32
+copy /B ..\ClassicStartMenu\Setup\ClassicStartMenu.pdb Output\PDB32 > nul
+copy /B Output\ClassicStartMenu.exe Output\PDB32 > nul
+copy /B ..\ClassicStartMenu\Setup\ClassicStartMenuDLL.pdb Output\PDB32 > nul
+copy /B Output\ClassicStartMenuDLL.dll Output\PDB32 > nul
+copy /B ..\ClassicStartMenu\StartMenuHelper\Setup\StartMenuHelper32.pdb Output\PDB32 > nul
+copy /B Output\StartMenuHelper32.dll Output\PDB32 > nul
+copy /B ..\ClassicStartUpdate\Release\ClassicStartUpdate.pdb Output\PDB32 > nul
+copy /B Output\ClassicStartUpdate.exe Output\PDB32 > nul
 
 REM Menu 64
-copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenu.pdb Output\PDB64
-copy /B Output\x64\ClassicStartMenu.exe Output\PDB64
-copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenuDLL.pdb Output\PDB64
-copy /B Output\x64\ClassicStartMenuDLL.dll Output\PDB64
-copy /B ..\ClassicStartMenu\StartMenuHelper\Setup64\StartMenuHelper64.pdb Output\PDB64
-copy /B Output\x64\StartMenuHelper64.dll Output\PDB64
+copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenu.pdb Output\PDB64 > nul
+copy /B Output\x64\ClassicStartMenu.exe Output\PDB64 > nul
+copy /B ..\ClassicStartMenu\Setup64\ClassicStartMenuDLL.pdb Output\PDB64 > nul
+copy /B Output\x64\ClassicStartMenuDLL.dll Output\PDB64 > nul
+copy /B ..\ClassicStartMenu\StartMenuHelper\Setup64\StartMenuHelper64.pdb Output\PDB64 > nul
+copy /B Output\x64\StartMenuHelper64.dll Output\PDB64 > nul
 
 
 REM ********* Build ADMX
+echo --- ADMX
 if exist Output\PolicyDefinitions.zip (
   del Output\PolicyDefinitions.zip
 )
@@ -117,8 +122,8 @@ cd ..\Localization\English
 ..\..\ClassicIE\Setup\ClassicIE_32.exe -saveadmx en-US
 @if ERRORLEVEL 1 exit /b 1
 md en-US
-copy /B *.adml en-US
-7z a ..\..\ClassicStartSetup\Output\PolicyDefinitions.zip *.admx en-US\*.adml PolicyDefinitions.rtf
+copy /B *.adml en-US > nul
+7z a ..\..\ClassicStartSetup\Output\PolicyDefinitions.zip *.admx en-US\*.adml PolicyDefinitions.rtf > nul
 rd /Q /S en-US
 cd ..\..\ClassicStartSetup
 

--- a/ClassicStartSrc/ClassicStartSetup/BuildInstaller.bat
+++ b/ClassicStartSrc/ClassicStartSetup/BuildInstaller.bat
@@ -1,10 +1,11 @@
 REM ********* Build Help
-echo "Building Installers"
+echo -- Building Installer (%CS_LANG_NAME_SHORT%)
 @setlocal EnableDelayedExpansion
 @if %CS_HAS_HELP%==1 (
+	echo --- HTML help
 	SET CS_ERROR=0
 	if NOT %CS_LANG_FOLDER%==English mklink /J ..\Localization\%CS_LANG_FOLDER%\images ..\Localization\English\images
-	hhc ..\Localization\%CS_LANG_FOLDER%\ClassicStart.hhp
+	hhc ..\Localization\%CS_LANG_FOLDER%\ClassicStart.hhp > nul
 	@REM looks like hhc returns 0 for error, >0 for success
 	@if NOT ERRORLEVEL 1 @SET CS_ERROR=1
 	if NOT %CS_LANG_FOLDER%==English rmdir ..\Localization\%CS_LANG_FOLDER%\images
@@ -12,11 +13,11 @@ echo "Building Installers"
 )
 @endlocal
 @if %CS_HAS_HELP%==0 (
-	copy /Y ..\Localization\English\ClassicStart.chm ..\Localization\%CS_LANG_FOLDER%\ClassicStart.chm
+	copy /Y ..\Localization\English\ClassicStart.chm ..\Localization\%CS_LANG_FOLDER%\ClassicStart.chm > nul
 )
 
-@if %CS_HAS_EULA%==0 copy /Y ..\Localization\English\ClassicStartEULA.rtf ..\Localization\%CS_LANG_FOLDER%
-@if %CS_HAS_README%==0 copy /Y ..\Localization\English\ClassicStartReadme.rtf ..\Localization\%CS_LANG_FOLDER%
+@if %CS_HAS_EULA%==0 copy /Y ..\Localization\English\ClassicStartEULA.rtf ..\Localization\%CS_LANG_FOLDER% > nul
+@if %CS_HAS_README%==0 copy /Y ..\Localization\English\ClassicStartReadme.rtf ..\Localization\%CS_LANG_FOLDER% > nul
 
 @if _%CS_LANG_NAME%==_ echo Unrecognized language '%CS_LANG_FOLDER%'
 @if _%CS_LANG_NAME%==_ exit /b 1
@@ -24,8 +25,8 @@ echo "Building Installers"
 SET CS_INSTALLER_NAME=ClassicStartSetup_%CS_VERSION_STR%-%CS_LANG_NAME_SHORT%
 if %CS_LANG_NAME_SHORT%==en SET CS_INSTALLER_NAME=ClassicStartSetup_%CS_VERSION_STR%
 
+if exist Temp rd /Q /S Temp
 md Temp
-del /Q Temp\*.*
 
 @if not exist ..\Localization\%CS_LANG_FOLDER%\ClassicStartText-%CS_LANG_NAME%.wxl exit /b 1
 
@@ -36,47 +37,47 @@ del /Q Temp\*.*
 )
 
 REM ********* Build 32-bit MSI
-candle ClassicStartSetup.wxs -out Temp\ClassicStartSetup32.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=0 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
+echo --- 32bit MSI
+candle ClassicStartSetup.wxs -nologo -out Temp\ClassicStartSetup32.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=0 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
 @if ERRORLEVEL 1 exit /b 1
 
 @REM We need to suppress ICE38 and ICE43 because they apply only to per-user installation. We only support per-machine installs
 @REM We need to suppress ICE09 because the helper DLLs need to go into the system directory (for safety reasons)
-light Temp\ClassicStartSetup32.wixobj -out Temp\ClassicStartSetup32.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicStartText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
+light Temp\ClassicStartSetup32.wixobj -nologo -out Temp\ClassicStartSetup32.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicStartText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
 @if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Build 64-bit MSI
-candle ClassicStartSetup.wxs -out Temp\ClassicStartSetup64.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=1 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
+echo --- 64bit MSI
+candle ClassicStartSetup.wxs -nologo -out Temp\ClassicStartSetup64.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=1 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
 @if ERRORLEVEL 1 exit /b 1
 
 @REM We need to suppress ICE38 and ICE43 because they apply only to per-user installation. We only support per-machine installs
 @REM We need to suppress ICE09 because the helper DLLs need to go into the system directory (for safety reasons)
-light Temp\ClassicStartSetup64.wixobj -out Temp\ClassicStartSetup64.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicStartText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
+light Temp\ClassicStartSetup64.wixobj -nologo -out Temp\ClassicStartSetup64.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicStartText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
 @if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Build MSI Checksums
-start /wait ClassicStartUtility\Release\ClassicStartUtility.exe crcmsi Temp
+echo --- MSI Checksums
+ClassicStartUtility\Release\ClassicStartUtility.exe crcmsi Temp
 @if ERRORLEVEL 1 exit /b 1
 
 REM ********* Build bootstrapper
+echo --- Bootstrapper
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
-"%MSBuildDir%MSBuild.exe" ClassicStartSetup.sln /m /t:Rebuild /p:Configuration="Release" /p:Platform="Win32" /verbosity:minimal
+"%MSBuildDir%MSBuild.exe" ClassicStartSetup.sln /m /t:Rebuild /p:Configuration="Release" /p:Platform="Win32" /verbosity:quiet /nologo
 @if ERRORLEVEL 1 exit /b 1
 
+if exist Final rd /Q /S Final
 md Final
 
-del Final\%CS_INSTALLER_NAME%.exe
-copy /B Release\ClassicStartSetup.exe Final\%CS_INSTALLER_NAME%.exe
+copy /B Release\ClassicStartSetup.exe Final\%CS_INSTALLER_NAME%.exe > nul
 
 if defined APPVEYOR (
 	appveyor PushArtifact Release\ClassicStartSetup.exe -FileName %CS_INSTALLER_NAME%.exe
 )
-
-md Output\Releases
-copy /B Final\%CS_INSTALLER_NAME%.exe Output\Releases\%CS_INSTALLER_NAME%.exe
-
 
 SET CS_LANG_FOLDER=
 SET CS_LANG_NAME=

--- a/ClassicStartSrc/ClassicStartSetup/CreateSourceIndex.bat
+++ b/ClassicStartSrc/ClassicStartSetup/CreateSourceIndex.bat
@@ -1,0 +1,41 @@
+@echo off
+
+rem CreateSourceIndex.bat <src-root-path>
+
+rem Create source index (write to stdout)
+
+rem Based on information provided here:
+rem https://gist.github.com/baldurk/c6feb31b0305125c6d1a
+
+rem expand src root
+set SRC_ROOT=%~fdp1
+
+rem get repo url
+for /f %%A in ('git remote get-url origin') do set REPO_URL=%%A
+rem remove .git from the end
+set REPO_URL=%REPO_URL:~0,-4%
+
+rem get actual commit id
+for /f %%A in ('git rev-parse HEAD') do set COMMIT=%%A
+
+echo SRCSRV: ini ------------------------------------------------
+echo VERSION=2
+echo VERCTRL=http
+echo SRCSRV: variables ------------------------------------------
+echo SRCSRVTRG=%REPO_URL%/raw/%COMMIT%/%%var2%%
+echo SRCSRV: source files ---------------------------------------
+
+setlocal enabledelayedexpansion
+for /f %%A in ('git ls-tree --full-tree -r --name-only head') do (
+	rem full path to source file
+	set SRC_FILE=%SRC_ROOT%\%%A
+	rem replace / by \
+	set SRC_FILE=!SRC_FILE:/=\!
+	rem convert to lowercase
+	for %%C in (a b c d e f g h i j k l m n o p q r s t u v w x y z) do set SRC_FILE=!SRC_FILE:%%C=%%C!
+	rem <full-path-to-src>*<relative-repo-path>
+	echo !SRC_FILE!*%%A
+)
+setlocal disabledelayedexpansion
+
+echo SRCSRV: end ------------------------------------------------

--- a/ClassicStartSrc/ClassicStartSetup/__MakeFinal.bat
+++ b/ClassicStartSrc/ClassicStartSetup/__MakeFinal.bat
@@ -18,6 +18,10 @@ echo Version: %CS_VERSION%
 rem Convert . to _
 set CS_VERSION_STR=%CS_VERSION:.=_%
 
+set CS_VERSION_ORIG=%CS_VERSION%
+rem Strip optional "-xyz" suffix from version
+for /f "delims=- tokens=1,1" %%i in ("%CS_VERSION%") do set CS_VERSION=%%i
+
 call BuildBinaries.bat
 if ERRORLEVEL 1 exit /b 1
 

--- a/ClassicStartSrc/ClassicStartSetup/__MakeFinal.bat
+++ b/ClassicStartSrc/ClassicStartSetup/__MakeFinal.bat
@@ -1,28 +1,30 @@
 @echo off
 set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.11\bin\;%PATH%
 
-@cd %~dp0
+cd %~dp0
 
-@rem Clean repository and build fresh. Will erase current changes so disabled by default.
+rem Clean repository and build fresh. Will erase current changes so disabled by default.
 rem git clean -dfx
 
-@rem Default version
-@set CS_VERSION=4.4.102
+rem Default version
+set CS_VERSION=4.4.102
 
-@if defined APPVEYOR_BUILD_VERSION (
-	@set CS_VERSION=%APPVEYOR_BUILD_VERSION%
+if defined APPVEYOR_BUILD_VERSION (
+	set CS_VERSION=%APPVEYOR_BUILD_VERSION%
 )
 
-@rem Convert . to _
-@set CS_VERSION_STR=%CS_VERSION:.=_%
+echo Version: %CS_VERSION%
 
-@call BuildBinaries.bat
-@if ERRORLEVEL 1 exit /b 1
+rem Convert . to _
+set CS_VERSION_STR=%CS_VERSION:.=_%
 
-@call _BuildEnglish.bat
-@if ERRORLEVEL 1 exit /b 1
+call BuildBinaries.bat
+if ERRORLEVEL 1 exit /b 1
+
+call _BuildEnglish.bat
+if ERRORLEVEL 1 exit /b 1
 
 call BuildArchives.bat
-@if ERRORLEVEL 1 exit /b 1
+if ERRORLEVEL 1 exit /b 1
 
-@exit /b 0
+exit /b 0

--- a/ClassicStartSrc/ClassicStartSetup/__MakeFinalAllLanguages.bat
+++ b/ClassicStartSrc/ClassicStartSetup/__MakeFinalAllLanguages.bat
@@ -1,48 +1,48 @@
-@rem @echo off
-@rem This file is to create all the files required for a new release to publish
+@echo off
+rem This file is to create all the files required for a new release to publish
 
 set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.11\bin\;%PATH%
 
-@cd %~dp0
+cd %~dp0
 
-@rem Clean repository and build fresh. Will erase current changes so disabled by default.
+rem Clean repository and build fresh. Will erase current changes so disabled by default.
 rem git clean -dfx
 
-@rem Default version
-@set CS_VERSION=4.3.2
+rem Default version
+set CS_VERSION=4.3.2
 
-@if defined APPVEYOR_BUILD_VERSION (
-	@set CS_VERSION=%APPVEYOR_BUILD_VERSION%
+if defined APPVEYOR_BUILD_VERSION (
+	set CS_VERSION=%APPVEYOR_BUILD_VERSION%
 )
 
-@rem Convert . to _
-@set CS_VERSION_STR=%CS_VERSION:.=_%
+rem Convert . to _
+set CS_VERSION_STR=%CS_VERSION:.=_%
 
-@call BuildBinaries.bat
-@if ERRORLEVEL 1 exit /b 1
+call BuildBinaries.bat
+if ERRORLEVEL 1 exit /b 1
 
-@call _BuildEnglish.bat
-@if ERRORLEVEL 1 exit /b 1
+call _BuildEnglish.bat
+if ERRORLEVEL 1 exit /b 1
 
-@rem Build other languages
-@call _BuildChineseCN.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildChineseTW.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildFrench.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildGerman.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildItalian.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildPolish.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildRussian.bat
-@if ERRORLEVEL 1 exit /b 1
-@call _BuildSpanish.bat
-@if ERRORLEVEL 1 exit /b 1
+rem Build other languages
+call _BuildChineseCN.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildChineseTW.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildFrench.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildGerman.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildItalian.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildPolish.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildRussian.bat
+if ERRORLEVEL 1 exit /b 1
+call _BuildSpanish.bat
+if ERRORLEVEL 1 exit /b 1
 
 call BuildArchives.bat
-@if ERRORLEVEL 1 exit /b 1
+if ERRORLEVEL 1 exit /b 1
 
-@exit /b 0
+exit /b 0

--- a/ClassicStartSrc/ClassicStartSetup/__MakeFinalAllLanguages.bat
+++ b/ClassicStartSrc/ClassicStartSetup/__MakeFinalAllLanguages.bat
@@ -18,6 +18,10 @@ if defined APPVEYOR_BUILD_VERSION (
 rem Convert . to _
 set CS_VERSION_STR=%CS_VERSION:.=_%
 
+set CS_VERSION_ORIG=%CS_VERSION%
+rem Strip optional "-xyz" suffix from version
+for /f "delims=- tokens=1,1" %%i in ("%CS_VERSION%") do set CS_VERSION=%%i
+
 call BuildBinaries.bat
 if ERRORLEVEL 1 exit /b 1
 

--- a/ClassicStartSrc/Version.props
+++ b/ClassicStartSrc/Version.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ResourceCompile>
-      <PreprocessorDefinitions>_PRODUCT_VERSION=$(CS_VERSION.Replace('.', ',')),0;_PRODUCT_VERSION_STR=\"$(CS_VERSION).0\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_PRODUCT_VERSION=$(CS_VERSION.Replace('.', ',')),0;_PRODUCT_VERSION_STR=\"$(CS_VERSION_ORIG)\";%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
 image: Visual Studio 2017
-shallow_clone: true
+clone_depth: 1
 build_script:
 - cmd: ClassicStartSrc\ClassicStartSetup\__MakeFinal.bat
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ pull_requests:
 skip_tags: true
 image: Visual Studio 2017
 shallow_clone: true
-install:
-- cmd: set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;C:\Program Files (x86)\HTML Help Workshop;%PATH%
 build_script:
 - cmd: ClassicStartSrc\ClassicStartSetup\__MakeFinal.bat
 test: off


### PR DESCRIPTION
- Add symbols to 7z archive (15MB vs 34MB)
- Don't create source package (obsolete)
- Less verbose output (removed unnecessary distracting messages)
- Remove unneeded install script
- Add source index to PDBs (so that exact sources are automatically fetched during debugging)

The output of `__MakeFinal.bat` now looks like this:

> Version: 4.4.102
> -- Compiling
> --- 64bit
> --- 32bit
> --- Adding source index to PDBs
> --- ADMX
> -- Building Installer (en)
> --- HTML help
> --- 32bit MSI
> --- 64bit MSI
> --- MSI Checksums
> --- Bootstrapper
> -- Creating symbols package
> -- Creating localization package